### PR TITLE
Add production configuration settings and ApplicationOptions

### DIFF
--- a/MARKET_READY_TODO.md
+++ b/MARKET_READY_TODO.md
@@ -12,11 +12,11 @@ This checklist breaks the remaining work into small, clear tasks to prepare the 
 
 ## 2. Application Configuration
 
-- [ ] Create `src/FnBManagement.Web/appsettings.Production.json` for production-safe logging and runtime settings.
-- [ ] Add environment variable documentation to `docs/ENVIRONMENT_VARIABLES.md`.
-- [ ] Add a `ConnectionStrings:DefaultConnection` placeholder to `src/FnBManagement.Web/appsettings.json`.
-- [ ] Create `src/FnBManagement.Web/Options/ApplicationOptions.cs` for product name, support email, currency, and timezone settings.
-- [ ] Register `ApplicationOptions` in `src/FnBManagement.Web/Program.cs`.
+- [x] Create `src/FnBManagement.Web/appsettings.Production.json` for production-safe logging and runtime settings.
+- [x] Add environment variable documentation to `docs/ENVIRONMENT_VARIABLES.md`.
+- [x] Add a `ConnectionStrings:DefaultConnection` placeholder to `src/FnBManagement.Web/appsettings.json`.
+- [x] Create `src/FnBManagement.Web/Options/ApplicationOptions.cs` for product name, support email, currency, and timezone settings.
+- [x] Register `ApplicationOptions` in `src/FnBManagement.Web/Program.cs`.
 
 ## 3. Data Persistence
 

--- a/docs/ENVIRONMENT_VARIABLES.md
+++ b/docs/ENVIRONMENT_VARIABLES.md
@@ -1,0 +1,36 @@
+# Environment Variables
+
+The FnB Management web application uses ASP.NET Core configuration, so environment variables override matching `appsettings.json` values. Use double underscores (`__`) to represent nested configuration keys.
+
+## Required in production
+
+| Environment variable | Configuration key | Description | Example |
+| --- | --- | --- | --- |
+| `ConnectionStrings__DefaultConnection` | `ConnectionStrings:DefaultConnection` | Database connection string used by the application. Store this in the deployment secret manager rather than source control. | `Host=db.example.com;Port=5432;Database=fnb_management;Username=fnb_app;Password=<secret>` |
+| `AllowedHosts` | `AllowedHosts` | Semicolon-delimited host names the ASP.NET Core host is allowed to serve. Avoid `*` in production. | `app.example.com;www.example.com` |
+
+## Application settings
+
+| Environment variable | Configuration key | Description | Default |
+| --- | --- | --- | --- |
+| `Application__ProductName` | `Application:ProductName` | Public product name shown in operational messages and future UI surfaces. | `FnB Management` |
+| `Application__SupportEmail` | `Application:SupportEmail` | Customer support contact email for production incidents and user help. | `support@example.com` |
+| `Application__Currency` | `Application:Currency` | ISO 4217 currency code used for prices, revenue, and reports. | `USD` |
+| `Application__Timezone` | `Application:Timezone` | IANA timezone used for business-day calculations and reports. | `UTC` |
+
+## Logging settings
+
+| Environment variable | Configuration key | Description | Production default |
+| --- | --- | --- | --- |
+| `Logging__LogLevel__Default` | `Logging:LogLevel:Default` | Minimum log level for application logs. | `Warning` |
+| `Logging__LogLevel__Microsoft.AspNetCore` | `Logging:LogLevel:Microsoft.AspNetCore` | Minimum log level for ASP.NET Core framework logs. | `Warning` |
+| `Logging__LogLevel__Microsoft.Hosting.Lifetime` | `Logging:LogLevel:Microsoft.Hosting.Lifetime` | Minimum log level for host lifecycle logs. | `Information` |
+
+## Local development example
+
+```bash
+export ConnectionStrings__DefaultConnection="Host=localhost;Port=5432;Database=fnb_management;Username=fnb_user;Password=change-me"
+export Application__SupportEmail="support@localhost"
+export Application__Currency="USD"
+export Application__Timezone="America/New_York"
+```

--- a/src/FnBManagement.Web/Options/ApplicationOptions.cs
+++ b/src/FnBManagement.Web/Options/ApplicationOptions.cs
@@ -1,0 +1,14 @@
+namespace FnBManagement.Web.Options;
+
+public class ApplicationOptions
+{
+    public const string SectionName = "Application";
+
+    public string ProductName { get; set; } = "FnB Management";
+
+    public string SupportEmail { get; set; } = "support@example.com";
+
+    public string Currency { get; set; } = "USD";
+
+    public string Timezone { get; set; } = "UTC";
+}

--- a/src/FnBManagement.Web/Program.cs
+++ b/src/FnBManagement.Web/Program.cs
@@ -1,9 +1,11 @@
 using FnBManagement.Web.Data;
 using FnBManagement.Web.Services;
+using FnBManagement.Web.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddControllersWithViews();
+builder.Services.Configure<ApplicationOptions>(builder.Configuration.GetSection(ApplicationOptions.SectionName));
 builder.Services.AddSingleton<InMemoryStore>();
 builder.Services.AddSingleton<IDashboardService, DashboardService>();
 

--- a/src/FnBManagement.Web/appsettings.Production.json
+++ b/src/FnBManagement.Web/appsettings.Production.json
@@ -1,0 +1,19 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": ""
+  },
+  "Application": {
+    "ProductName": "FnB Management",
+    "SupportEmail": "support@example.com",
+    "Currency": "USD",
+    "Timezone": "UTC"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": ""
+}

--- a/src/FnBManagement.Web/appsettings.json
+++ b/src/FnBManagement.Web/appsettings.json
@@ -1,0 +1,18 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=fnb_management;Username=fnb_user;Password=change-me"
+  },
+  "Application": {
+    "ProductName": "FnB Management",
+    "SupportEmail": "support@example.com",
+    "Currency": "USD",
+    "Timezone": "UTC"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
### Motivation
- Provide a production-safe configuration baseline with safe logging defaults and a connection-string placeholder for secret injection. 
- Expose runtime application metadata (product name, support email, currency, timezone) via strongly-typed options for future runtime and UI use. 
- Document environment-variable usage so deployments can override secrets and runtime settings securely.

### Description
- Add `src/FnBManagement.Web/appsettings.json` with a `ConnectionStrings:DefaultConnection` placeholder, `Application` defaults, logging defaults, and `AllowedHosts` set for local use. 
- Add `src/FnBManagement.Web/appsettings.Production.json` with an empty `DefaultConnection`, production-safe logging levels, and empty `AllowedHosts` to encourage secret and environment injection. 
- Create `src/FnBManagement.Web/Options/ApplicationOptions.cs` to represent `Application` settings and register it in `src/FnBManagement.Web/Program.cs` via `builder.Services.Configure<ApplicationOptions>(...)`. 
- Add `docs/ENVIRONMENT_VARIABLES.md` documenting the environment variables that map to configuration keys and update the product checklist to mark these items done.

### Testing
- Ran JSON validation on the new configuration files with `python3 -m json.tool src/FnBManagement.Web/appsettings.json` which succeeded. 
- Ran JSON validation on the production configuration with `python3 -m json.tool src/FnBManagement.Web/appsettings.Production.json` which succeeded. 
- Attempted `dotnet build FnBManagement.sln` but it could not run in this environment because `dotnet` is not installed, so a full build was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38eda5e0f083249a2a8c63707587c9)